### PR TITLE
Allow empty passwords.

### DIFF
--- a/v8/credentials/credentials.go
+++ b/v8/credentials/credentials.go
@@ -129,11 +129,9 @@ func (c *Credentials) Password() string {
 }
 
 // HasPassword queries if the Credentials has a password defined.
+// Empty passwords are allowed, therefore we always return true. We keep this method for compatibility purposes.
 func (c *Credentials) HasPassword() bool {
-	if c.password != "" {
-		return true
-	}
-	return false
+	return true
 }
 
 // SetValidUntil sets the expiry time of the credentials


### PR DESCRIPTION
Empty passwords are allowed in Kerberos, this pull request fixes that. The var `c.password` is a string, so is always a valid password. I kept the function `HasPassword` for backwards compatibility reasons so that other programs using this dependency don't have to change code. This pull request also enables Kerbrute to spray empty passwords (which is the main reason I updated this dependency).