### PR TITLE
Implemented AddEntryWithHash and setpreAuthEType

### DIFF
--- a/v8/client/settings.go
+++ b/v8/client/settings.go
@@ -38,6 +38,12 @@ func DisablePAFXFAST(b bool) func(*Settings) {
 	}
 }
 
+func SetpreAuthEType(etype int32) func(*Settings) {
+	return func(s *Settings) {
+		s.preAuthEType = etype
+	}
+}
+
 // DisablePAFXFAST indicates is the client should disable the use of PA_FX_FAST.
 func (s *Settings) DisablePAFXFAST() bool {
 	return s.disablePAFXFast

--- a/v8/keytab/keytab.go
+++ b/v8/keytab/keytab.go
@@ -4,6 +4,7 @@ package keytab
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -122,6 +123,41 @@ func (kt Keytab) String() string {
 		s += entry.String() + "\n"
 	}
 	return s
+}
+
+// AddEntry adds an entry to the keytab with a precomputed hash. The hash should be provided in hex format.
+func (kt *Keytab) AddEntryWithHash(principalName, realm, hash string, ts time.Time, KVNO uint8, encType int32) error {
+	princ, _ := types.ParseSPNString(principalName)
+
+	hashBytes, err := hex.DecodeString(hash)
+	if err != nil {
+		panic(err)
+	}
+	key := types.EncryptionKey{
+		KeyType:  encType,
+		KeyValue: hashBytes,
+	}
+	// Populate the keytab entry principal
+	ktep := newPrincipal()
+	ktep.NumComponents = int16(len(princ.NameString))
+	if kt.version == 1 {
+		ktep.NumComponents += 1
+	}
+
+	ktep.Realm = realm
+	ktep.Components = princ.NameString
+	ktep.NameType = princ.NameType
+
+	// Populate the keytab entry
+	e := newEntry()
+	e.Principal = ktep
+	e.Timestamp = ts
+	e.KVNO8 = KVNO
+	e.KVNO = uint32(KVNO)
+	e.Key = key
+
+	kt.Entries = append(kt.Entries, e)
+	return nil
 }
 
 // AddEntry adds an entry to the keytab. The password should be provided in plain text and it will be converted using the defined enctype to be stored.


### PR DESCRIPTION
Created a new function AddEntryWithHash and setpreAuthEType to add support for pass-the-hash feature for kerbrute.

There might not have been a need for setpreAuthEType but it looked clean to be able to pass it in as an argument.